### PR TITLE
Fix(Youtube Node) fix(Youtube Node) Align playlist creation test with privacyStatus fix #16442

### DIFF
--- a/packages/nodes-base/nodes/Google/YouTube/__test__/node/YouTube.node.test.ts
+++ b/packages/nodes-base/nodes/Google/YouTube/__test__/node/YouTube.node.test.ts
@@ -71,7 +71,8 @@ describe('Test YouTube Node', () => {
 		beforeAll(() => {
 			youtubeNock
 				.post('/v3/playlists', {
-					snippet: { title: 'Playlist 1', privacyStatus: 'public', defaultLanguage: 'en' },
+					snippet: { title: 'Playlist 1', defaultLanguage: 'en' },
+					status: { privacyStatus: 'public' },
 				})
 				.query({ part: 'snippet' })
 				.reply(200, playlists[0]);


### PR DESCRIPTION
## Summary

The `privacyStatus` for YouTube playlist creation was incorrectly mapped to `body.snippet.privacyStatus`. This commit
corrects the path to `body.status.privacyStatus` as per [YouTube Data API v3 documentation](https://developers.google.com/youtube/v3/docs/playlists#resource), ensuring the
privacy setting selected in the node is respected.

## Related Linear tickets, Github issues, and Community forum posts

resolves #16442

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
